### PR TITLE
Fix bugs in static constructor

### DIFF
--- a/RockLib.UniversalMemberAccessor.UnitTests/UniversalMemberAccessorTests.cs
+++ b/RockLib.UniversalMemberAccessor.UnitTests/UniversalMemberAccessorTests.cs
@@ -996,6 +996,19 @@ namespace RockLib.Dynamic.UnitTests
             Assert.That(bar, Is.EqualTo(fieldValue));
         }
 
+#if NETCOREAPP3_0
+        [Test]
+        public void CannotSetReadonlyReferenceTypeStaticField()
+        {
+            var type = Create.Class("Foo", Define.Field("_bar", typeof(string), true, true));
+
+            var foo = type.Unlock();
+
+            Assert.That(() => foo._bar = "abc",
+                Throws.InstanceOf<NotSupportedException>().With.Message.EqualTo(
+                "The current runtime does not allow the (illegal) changing of readonly static reference-type fields."));
+        }
+#else
         [Test]
         public void CanSetReadonlyReferenceTypeStaticField()
         {
@@ -1008,8 +1021,9 @@ namespace RockLib.Dynamic.UnitTests
             var bar = foo._bar;
             Assert.That(bar, Is.EqualTo("abc"));
         }
+#endif
 
-#if NET40
+#if NET40 || NETCOREAPP3_0
         [Test]
         public void CannotSetReadonlyValueTypeStaticField()
         {

--- a/RockLib.UniversalMemberAccessor.UnitTests/netcoreapp2.1/RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.1.csproj
+++ b/RockLib.UniversalMemberAccessor.UnitTests/netcoreapp2.1/RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/RockLib.UniversalMemberAccessor.UnitTests/netcoreapp2.2/RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.2.csproj
+++ b/RockLib.UniversalMemberAccessor.UnitTests/netcoreapp2.2/RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/RockLib.UniversalMemberAccessor.UnitTests/netcoreapp3.0/RockLib.UniversalMemberAccessor.UnitTests.netcoreapp3.0.csproj
+++ b/RockLib.UniversalMemberAccessor.UnitTests/netcoreapp3.0/RockLib.UniversalMemberAccessor.UnitTests.netcoreapp3.0.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/RockLib.UniversalMemberAccessor.appveyor.yml
+++ b/RockLib.UniversalMemberAccessor.appveyor.yml
@@ -1,5 +1,5 @@
 version: 'RockLib.UniversalMemberAccessor.{build}.0.0-ci'
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 only_commits:
   files:

--- a/RockLib.UniversalMemberAccessor.sln
+++ b/RockLib.UniversalMemberAccessor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29326.143
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.UniversalMemberAccessor", "RockLib.UniversalMemberAccessor\RockLib.UniversalMemberAccessor.csproj", "{587A1310-2E6F-4C9B-9B8C-5F0C9A5F23E7}"
 EndProject
@@ -10,6 +10,12 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.UniversalMemberAccessor.UnitTests.net40", "RockLib.UniversalMemberAccessor.UnitTests\net40\RockLib.UniversalMemberAccessor.UnitTests.net40.csproj", "{02B7AC42-37B1-4EE2-9BCC-3F6D0A047449}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.0", "RockLib.UniversalMemberAccessor.UnitTests\netcoreapp2.0\RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.0.csproj", "{E8D5530C-E4CC-4521-9473-0663B03D2DE7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.1", "RockLib.UniversalMemberAccessor.UnitTests\netcoreapp2.1\RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.1.csproj", "{93EC54CF-D2C5-4E49-9EC1-301A780F1C35}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.2", "RockLib.UniversalMemberAccessor.UnitTests\netcoreapp2.2\RockLib.UniversalMemberAccessor.UnitTests.netcoreapp2.2.csproj", "{1C154E11-1AB9-43CB-9D81-13FE0AF1E966}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.UniversalMemberAccessor.UnitTests.netcoreapp3.0", "RockLib.UniversalMemberAccessor.UnitTests\netcoreapp3.0\RockLib.UniversalMemberAccessor.UnitTests.netcoreapp3.0.csproj", "{70451B1C-0131-4D87-9545-37236300D1AE}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -32,6 +38,18 @@ Global
 		{E8D5530C-E4CC-4521-9473-0663B03D2DE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E8D5530C-E4CC-4521-9473-0663B03D2DE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E8D5530C-E4CC-4521-9473-0663B03D2DE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93EC54CF-D2C5-4E49-9EC1-301A780F1C35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93EC54CF-D2C5-4E49-9EC1-301A780F1C35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93EC54CF-D2C5-4E49-9EC1-301A780F1C35}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93EC54CF-D2C5-4E49-9EC1-301A780F1C35}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C154E11-1AB9-43CB-9D81-13FE0AF1E966}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C154E11-1AB9-43CB-9D81-13FE0AF1E966}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C154E11-1AB9-43CB-9D81-13FE0AF1E966}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1C154E11-1AB9-43CB-9D81-13FE0AF1E966}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70451B1C-0131-4D87-9545-37236300D1AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70451B1C-0131-4D87-9545-37236300D1AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70451B1C-0131-4D87-9545-37236300D1AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70451B1C-0131-4D87-9545-37236300D1AE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RockLib.UniversalMemberAccessor/UniversalMemberAccessor.cs
+++ b/RockLib.UniversalMemberAccessor/UniversalMemberAccessor.cs
@@ -65,17 +65,45 @@ namespace RockLib.Dynamic
             var initialInstanceValueType = readonlyFields.InstanceValueType;
             var initialInstanceReferenceType = readonlyFields.InstanceReferenceType;
 
-            // ReSharper disable PossibleNullReferenceException
-            staticValueTypeField.SetValue(null, 9);
-            staticReferenceTypeField.SetValue(null, "Z");
-            instanceValueTypeField.SetValue(readonlyFields, 8);
-            instanceReferenceTypeField.SetValue(readonlyFields, "Y");
-            // ReSharper restore PossibleNullReferenceException
+            try
+            {
+                staticValueTypeField.SetValue(null, 9);
+                _canSetReadonlyStaticValueType = (ReadonlyFields.StaticValueType != initialStaticValueType);
+            }
+            catch
+            {
+                _canSetReadonlyStaticValueType = false;
+            }
 
-            _canSetReadonlyStaticValueType = (ReadonlyFields.StaticValueType != initialStaticValueType);
-            _canSetReadonlyStaticReferenceType = (ReadonlyFields.StaticReferenceType != initialStaticReferenceType);
-            _canSetReadonlyInstanceValueType = (readonlyFields.InstanceValueType != initialInstanceValueType);
-            _canSetReadonlyInstanceReferenceType = (readonlyFields.InstanceReferenceType != initialInstanceReferenceType);
+            try
+            {
+                staticReferenceTypeField.SetValue(null, "Z");
+                _canSetReadonlyStaticReferenceType = (ReadonlyFields.StaticReferenceType != initialStaticReferenceType);
+            }
+            catch
+            {
+                _canSetReadonlyStaticReferenceType = false;
+            }
+
+            try
+            {
+                instanceValueTypeField.SetValue(readonlyFields, 8);
+                _canSetReadonlyInstanceValueType = (readonlyFields.InstanceValueType != initialInstanceValueType);
+            }
+            catch
+            {
+                _canSetReadonlyInstanceValueType = false;
+            }
+
+            try
+            {
+                instanceReferenceTypeField.SetValue(readonlyFields, "Y");
+                _canSetReadonlyInstanceReferenceType = (readonlyFields.InstanceReferenceType != initialInstanceReferenceType);
+            }
+            catch
+            {
+                _canSetReadonlyInstanceReferenceType = false;
+            }
 
             // Need to use some reflection in order to get the generic type arguments supplied by the caller.
             // Note that Visual Basic's late binding does not support generic type arguments.
@@ -85,7 +113,7 @@ namespace RockLib.Dynamic
             {
                 var property = cSharpBinderType.GetProperty("TypeArguments");
 
-                if (property != null && property.PropertyType == typeof(IList<Type>))
+                if (property != null && typeof(IList<Type>).IsAssignableFrom(property.PropertyType))
                 {
                     var binderParameter = Expression.Parameter(typeof(InvokeMemberBinder), "binder");
 


### PR DESCRIPTION
In .NET Core 2.1 and above, the signature of the `TypeArguments` property of the internal `ICSharpInvokeOrInvokeMemberBinder` interface changed from `IList<Type>` to `Type[]`. What this boils down to is that generic arguments were not being captured in a small number of cases.

In .NET Core 3.0, static readonly fields are enforced by reflection. This caused the static constructor of UniversalMemberAccessor to throw a TypeInitializationException when it performed feature detection on whether modifying readonly fields is supported. The solution is to wrap the feature detection in try/catch blocks.